### PR TITLE
Add Order Management System prototype

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 .DS_Store
 aws.json
 .Rhistory
+# OMS files
+oms/credentials.json
+__pycache__/

--- a/oms/README.md
+++ b/oms/README.md
@@ -1,0 +1,65 @@
+# Order Management System (OMS)
+
+This is a demonstration Order Management System that integrates with multiple
+mock e-commerce platforms. It exposes a simple REST API using FastAPI.
+
+## Features
+
+- Retrieve quotes for items from Amazon, eBay, and Walmart connectors.
+- Place orders on these platforms using stored credentials.
+- In-memory order storage and simple credential management.
+
+**Note:** The connectors are mock implementations and do not contact real
+services. Encryption of credentials is simplified and should not be used in
+production.
+
+## Setup
+
+1. Install Python 3.11 (already available in this environment).
+2. Install dependencies (FastAPI and pytest are already available in this environment):
+   ```bash
+   pip install fastapi pytest  # if not already installed
+   ```
+   If the environment lacks network access, ensure these packages are present.
+
+## Running the API
+
+```bash
+uvicorn oms.app:app --reload
+```
+
+## API Endpoints
+
+### `POST /quotes`
+Request body:
+```json
+{
+  "items": ["ITEM1", "ITEM2"],
+  "platforms": ["amazon", "ebay", "walmart"]
+}
+```
+
+Response contains quote information for each item/platform pair.
+
+### `POST /orders`
+Request body:
+```json
+{
+  "platform": "amazon",
+  "item_id": "ITEM1",
+  "credentials_id": "cred1",
+  "shipping_address": "123 Example St"
+}
+```
+
+Returns the placed order with an `order_id` that can be queried later.
+
+### `GET /orders/<order_id>`
+Returns order details.
+
+## Testing
+
+Run tests with `pytest`:
+```bash
+pytest oms/tests
+```

--- a/oms/__init__.py
+++ b/oms/__init__.py
@@ -1,0 +1,3 @@
+"""Order Management System package."""
+
+from .app import create_app

--- a/oms/app.py
+++ b/oms/app.py
@@ -1,0 +1,70 @@
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel
+
+from .platforms import CONNECTORS, get_connector
+from .credentials import get_credential
+from .orders import create_order, get_order
+
+app = FastAPI()
+
+
+class QuoteRequest(BaseModel):
+    items: list[str] = []
+    platforms: list[str] | None = None
+
+
+class OrderRequest(BaseModel):
+    platform: str
+    item_id: str
+    credentials_id: str
+    shipping_address: str = ""
+
+
+@app.post("/quotes")
+def quotes(req: QuoteRequest):
+    items = req.items
+    platforms = req.platforms or list(CONNECTORS.keys())
+    responses = []
+    errors = []
+    for item in items:
+        for platform in platforms:
+            connector = get_connector(platform)
+            if not connector:
+                errors.append({"item_id": item, "platform": platform, "error": "unknown platform"})
+                continue
+            try:
+                responses.append(connector.get_quote(item))
+            except Exception as exc:  # pragma: no cover - unexpected errors
+                errors.append({"item_id": item, "platform": platform, "error": str(exc)})
+    return {"quotes": responses, "errors": errors}
+
+
+@app.post("/orders")
+def orders(req: OrderRequest):
+    connector = get_connector(req.platform)
+    if not connector:
+        raise HTTPException(status_code=400, detail="unknown platform")
+    creds = get_credential(req.credentials_id)
+    if not creds:
+        raise HTTPException(status_code=400, detail="credentials not found")
+    result = connector.place_order(req.item_id, creds, req.shipping_address)
+    order = create_order(result)
+    return order
+
+
+@app.get("/orders/{order_id}")
+def order_status(order_id: str):
+    order = get_order(order_id)
+    if not order:
+        raise HTTPException(status_code=404, detail="order not found")
+    return order
+
+
+def create_app() -> FastAPI:
+    return app
+
+
+if __name__ == "__main__":
+    import uvicorn
+
+    uvicorn.run(app, host="0.0.0.0", port=8000)

--- a/oms/credentials.py
+++ b/oms/credentials.py
@@ -1,0 +1,42 @@
+"""Simple credential storage using base64 encoding as placeholder encryption."""
+import base64
+import json
+import os
+from typing import Dict
+
+CREDENTIAL_FILE = os.path.join(os.path.dirname(__file__), "credentials.json")
+
+
+def load_credentials() -> Dict[str, dict]:
+    if not os.path.exists(CREDENTIAL_FILE):
+        return {}
+    with open(CREDENTIAL_FILE, "r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def save_credentials(creds: Dict[str, dict]):
+    with open(CREDENTIAL_FILE, "w", encoding="utf-8") as f:
+        json.dump(creds, f)
+
+
+def add_credential(cred_id: str, data: dict):
+    creds = load_credentials()
+    encoded = base64.b64encode(json.dumps(data).encode()).decode()
+    creds[cred_id] = encoded
+    save_credentials(creds)
+
+
+def get_credential(cred_id: str) -> dict | None:
+    creds = load_credentials()
+    encoded = creds.get(cred_id)
+    if not encoded:
+        return None
+    decoded = base64.b64decode(encoded).decode()
+    return json.loads(decoded)
+
+
+def remove_credential(cred_id: str):
+    creds = load_credentials()
+    if cred_id in creds:
+        creds.pop(cred_id)
+        save_credentials(creds)

--- a/oms/orders.py
+++ b/oms/orders.py
@@ -1,0 +1,16 @@
+"""In-memory order store."""
+import uuid
+from typing import Dict
+
+ORDERS: Dict[str, dict] = {}
+
+
+def create_order(data: dict) -> dict:
+    order_id = str(uuid.uuid4())
+    data["order_id"] = order_id
+    ORDERS[order_id] = data
+    return data
+
+
+def get_order(order_id: str) -> dict | None:
+    return ORDERS.get(order_id)

--- a/oms/platforms/__init__.py
+++ b/oms/platforms/__init__.py
@@ -1,0 +1,14 @@
+from .amazon import AmazonConnector
+from .ebay import EbayConnector
+from .walmart import WalmartConnector
+
+
+CONNECTORS = {
+    "amazon": AmazonConnector(),
+    "ebay": EbayConnector(),
+    "walmart": WalmartConnector(),
+}
+
+
+def get_connector(name: str):
+    return CONNECTORS.get(name)

--- a/oms/platforms/amazon.py
+++ b/oms/platforms/amazon.py
@@ -1,0 +1,26 @@
+import random
+from .base import PlatformConnector
+
+
+class AmazonConnector(PlatformConnector):
+    name = "amazon"
+
+    def get_quote(self, item_id: str) -> dict:
+        return {
+            "item_id": item_id,
+            "platform": self.name,
+            "price": round(random.uniform(5, 100), 2),
+            "availability": random.choice([True, False]),
+            "shipping_cost": round(random.uniform(0, 10), 2),
+            "estimated_delivery": f"{random.randint(2, 7)} days",
+        }
+
+    def place_order(self, item_id: str, credentials: dict, shipping_address: str) -> dict:
+        # This is a mock implementation.
+        return {
+            "order_id": f"AMZ-{random.randint(1000,9999)}",
+            "status": "placed",
+            "platform": self.name,
+            "item_id": item_id,
+            "tracking_id": f"TRK-{random.randint(10000,99999)}",
+        }

--- a/oms/platforms/base.py
+++ b/oms/platforms/base.py
@@ -1,0 +1,9 @@
+class PlatformConnector:
+    """Base class for platform connectors."""
+    name = "base"
+
+    def get_quote(self, item_id: str) -> dict:
+        raise NotImplementedError
+
+    def place_order(self, item_id: str, credentials: dict, shipping_address: str) -> dict:
+        raise NotImplementedError

--- a/oms/platforms/ebay.py
+++ b/oms/platforms/ebay.py
@@ -1,0 +1,25 @@
+import random
+from .base import PlatformConnector
+
+
+class EbayConnector(PlatformConnector):
+    name = "ebay"
+
+    def get_quote(self, item_id: str) -> dict:
+        return {
+            "item_id": item_id,
+            "platform": self.name,
+            "price": round(random.uniform(5, 100), 2),
+            "availability": random.choice([True, False]),
+            "shipping_cost": round(random.uniform(0, 10), 2),
+            "estimated_delivery": f"{random.randint(3, 8)} days",
+        }
+
+    def place_order(self, item_id: str, credentials: dict, shipping_address: str) -> dict:
+        return {
+            "order_id": f"EBY-{random.randint(1000,9999)}",
+            "status": "placed",
+            "platform": self.name,
+            "item_id": item_id,
+            "tracking_id": f"TRK-{random.randint(10000,99999)}",
+        }

--- a/oms/platforms/walmart.py
+++ b/oms/platforms/walmart.py
@@ -1,0 +1,25 @@
+import random
+from .base import PlatformConnector
+
+
+class WalmartConnector(PlatformConnector):
+    name = "walmart"
+
+    def get_quote(self, item_id: str) -> dict:
+        return {
+            "item_id": item_id,
+            "platform": self.name,
+            "price": round(random.uniform(5, 100), 2),
+            "availability": random.choice([True, False]),
+            "shipping_cost": round(random.uniform(0, 10), 2),
+            "estimated_delivery": f"{random.randint(4, 9)} days",
+        }
+
+    def place_order(self, item_id: str, credentials: dict, shipping_address: str) -> dict:
+        return {
+            "order_id": f"WMT-{random.randint(1000,9999)}",
+            "status": "placed",
+            "platform": self.name,
+            "item_id": item_id,
+            "tracking_id": f"TRK-{random.randint(10000,99999)}",
+        }

--- a/oms/requirements.txt
+++ b/oms/requirements.txt
@@ -1,0 +1,2 @@
+fastapi
+pytest

--- a/oms/tests/test_api.py
+++ b/oms/tests/test_api.py
@@ -1,0 +1,32 @@
+import json
+from oms.app import quotes as quotes_handler, orders as orders_handler, order_status as order_status_handler, QuoteRequest, OrderRequest
+from oms.credentials import add_credential, remove_credential
+
+
+def setup_module(module):
+    add_credential("cred1", {"username": "user", "password": "pass"})
+
+
+def teardown_module(module):
+    remove_credential("cred1")
+
+
+def test_quotes():
+    # Call handler directly instead of HTTP request
+    req = QuoteRequest(items=["A1"], platforms=["amazon", "ebay", "walmart"])
+    data = quotes_handler(req)
+    assert "quotes" in data
+    assert len(data["quotes"]) == 3
+
+
+def test_order_flow():
+    req = OrderRequest(
+        platform="amazon",
+        item_id="A1",
+        credentials_id="cred1",
+        shipping_address="123",
+    )
+    order = orders_handler(req)
+    oid = order["order_id"]
+    data2 = order_status_handler(oid)
+    assert data2["order_id"] == oid


### PR DESCRIPTION
## Summary
- implement a simple OMS package with mock e-commerce connectors
- expose REST-like API via FastAPI
- add in-memory credential and order storage helpers
- provide tests for basic API behaviour using handler functions directly
- document usage and configuration
- update `.gitignore` for OMS artifacts

## Testing
- `pytest oms/tests -q`